### PR TITLE
Default theme (smoothness) configuration setting fix

### DIFF
--- a/config.py
+++ b/config.py
@@ -138,7 +138,7 @@ configuration = [
 [
 'cfg_theme',
 "UI theme",
-'smoothness/jquery-ui.min.css'
+'smoothness/theme.css'
 ],
 
 [

--- a/tvstreamrecord.py
+++ b/tvstreamrecord.py
@@ -229,7 +229,7 @@ def checkLang():
         ret_loc = True
     ret_style = ( fileexists("css/" + config.cfg_theme) )
     if not ret_style:
-        config.cfg_theme = "smoothness/jquery-ui-1.10.4.custom.min.css"
+        config.cfg_theme = "smoothness/theme.css"
         print ("Theme not found, reverting to default theme")
     if not (ret_loc and ret_lng and ret_style):
         config.saveConfig()


### PR DESCRIPTION
After first start the configuration parameter "Interface theme" is empty in the GUI, i.e. it is not "smoothness":

![TSR_empty_theme](https://user-images.githubusercontent.com/155545/218208391-5e58c84c-8349-4e00-8e0a-2ddbb15973bc.png)

If you just change the recording path configuration (or nothing at all) and press "Submit changes" the current theme suddenly is lost. Example screenshot shows the channels page:

![TSR_no_theme](https://user-images.githubusercontent.com/155545/218208379-c9f58783-04f6-4ed5-8c63-f768de53ea85.png)

Root cause for this is wrong default setting of the theme in config.py and tvstreamrecord.py.

(Please note that in the 2 files there are different line ending characters for a few lines which was automatically fixed by the code editor on save. That's the reason why the diffs show these lines, too.)